### PR TITLE
Patch move_interface.

### DIFF
--- a/src/move_interface.cpp
+++ b/src/move_interface.cpp
@@ -6,14 +6,14 @@ MoveInterface::MoveInterface(BoardState &board_state)
 auto MoveInterface::input_to_move(std::vector<Move> possible_moves,
                                   std::string string_move) -> Move {
   Piece *moving_piece;
-  Piece *captured_piece = nullptr;
-  PieceType promotion_piece_type = PieceType::EMPTY;
+  Piece *captured_piece;
+  PieceType promotion_piece_type;
   int from_x, from_y;
   int to_x, to_y;
-  bool is_en_passant = false;
+  bool is_en_passant;
   bool first_move;
-  bool pawn_moved_two = false;
-  int pmt_x = -1, pmt_y = -1;
+  bool pawn_moved_two;
+  int pmt_x, pmt_y;
 
   char piece_type;
   int i = 0;

--- a/src/move_interface.cpp
+++ b/src/move_interface.cpp
@@ -18,14 +18,22 @@ auto MoveInterface::input_to_move(std::vector<Move> possible_moves,
   char piece_type;
   int i = 0;
   while (i == 0) {
+    // Reset variables.
+    captured_piece = nullptr;
+    promotion_piece_type = PieceType::EMPTY;
+    is_en_passant = false;
+    pawn_moved_two = false;
+    pmt_x = -1, pmt_y = -1;
+
+    // Get move from user.
     std::cout << "Enter move: ";
     std::cin >> string_move;
     std::cout << std::endl;
+
+    // Check if move is valid.
+    std::smatch matches;
     std::regex moveRegex(
         R"(^(O-O(?:-O)?)|([kqrbnp])([a-h][1-8])(x)?([a-h][1-8])=?([qrbns])?([+#])?$)");
-
-    std::smatch matches;
-
     if (std::regex_match(string_move, matches, moveRegex)) {
       if (matches[1].matched) {
         // Castle Move.


### PR DESCRIPTION
When player inputs an invalid capture move, captured_piece is given a value, when player is prompted to enter another move, captured_piece is not reset. Any other move the player enters after, that is not a valid capture move, will be rejected.

Fix: Reset all variables that have a default value when player is prompted to enter a move.