### PR TITLE
Patch TT Entry Usage Condition

### DIFF
--- a/include/search_engine.h
+++ b/include/search_engine.h
@@ -50,9 +50,6 @@ private:
   // Use for starting values of alpha and beta;
   const int INF = std::numeric_limits<int>::max();
 
-  // Max depth to search at current iteration.
-  int iterative_depth_search = 0;
-
   // Number of leaf nodes visited.
   std::atomic<int> leaf_nodes_visited = 0;
 

--- a/include/transposition_table.h
+++ b/include/transposition_table.h
@@ -12,7 +12,7 @@
  */
 struct TranspositionTableEntry {
   // Maximum depth of the search.
-  int max_depth;
+  int search_depth;
 
   // Value of the board state.
   int eval_score;
@@ -38,24 +38,24 @@ public:
    * @brief Store a new entry in the transposition table.
    *
    * @param board_state Board state to store.
-   * @param max_depth Maximum depth of the search.
+   * @param search_depth Depth searched for this position.
    * @param eval_score Evaluation score of the board state.
    * @param flag Flag of the value.
    */
-  void store(uint64_t &hash, int max_depth, int eval_score, int flag,
+  void store(uint64_t &hash, int search_depth, int eval_score, int flag,
              int best_move_index);
 
   /**
    * @brief Retrieve an entry from the transposition table.
    *
    * @param board_state Board state to retrieve.
-   * @param max_depth Maximum depth of the search.
+   * @param search_depth Depth searched for this position.
    * @param eval_score Evaluation score of the board state.
    * @param flag Flag of the value.
    *
    * @return true if the entry was found, false otherwise.
    */
-  auto retrieve(uint64_t &hash, int &depth, int &eval_score, int &flag,
+  auto retrieve(uint64_t &hash, int &search_depth, int &eval_score, int &flag,
                 int &best_move_index) -> bool;
   /**
    * @brief Get the size of the transposition table.

--- a/src/transposition_table.cpp
+++ b/src/transposition_table.cpp
@@ -5,7 +5,7 @@ TranspositionTable::TranspositionTable(uint64_t max_size)
     : max_size(max_size) {}
 
 // PUBLIC FUNCTIONS
-void TranspositionTable::store(uint64_t &hash, int max_depth, int eval_score,
+void TranspositionTable::store(uint64_t &hash, int search_depth, int eval_score,
                                int flag, int best_move_index) {
   // Lock the table.
   std::lock_guard<std::mutex> lock(mutex);
@@ -13,7 +13,7 @@ void TranspositionTable::store(uint64_t &hash, int max_depth, int eval_score,
 
   if (it != table.end()) {
     // Update existing entry
-    it->second.max_depth = max_depth;
+    it->second.search_depth = search_depth;
     it->second.eval_score = eval_score;
     it->second.flag = flag;
     it->second.best_move_index = best_move_index;
@@ -23,7 +23,7 @@ void TranspositionTable::store(uint64_t &hash, int max_depth, int eval_score,
     if (table.size() >= max_size) {
       trim();
     }
-    table[hash] = {max_depth, eval_score, flag, lru_list.end(),
+    table[hash] = {search_depth, eval_score, flag, lru_list.end(),
                    best_move_index};
   }
 
@@ -32,7 +32,7 @@ void TranspositionTable::store(uint64_t &hash, int max_depth, int eval_score,
   table[hash].lru_position = lru_list.begin();
 }
 
-auto TranspositionTable::retrieve(uint64_t &hash, int &max_depth,
+auto TranspositionTable::retrieve(uint64_t &hash, int &search_depth,
                                   int &eval_score, int &flag,
                                   int &best_move_index) -> bool {
   // Lock the table.
@@ -42,7 +42,7 @@ auto TranspositionTable::retrieve(uint64_t &hash, int &max_depth,
   if (it != table.end()) {
     eval_score = it->second.eval_score;
     flag = it->second.flag;
-    max_depth = it->second.max_depth;
+    search_depth = it->second.search_depth;
     best_move_index = it->second.best_move_index;
 
     // Update LRU list


### PR DESCRIPTION
Condition to use TT entry was wrong.
This patch ensures that TT entries are only used if the entry is searched at an equal or greater depth than what the node would search to.