### PR TITLE
Implement Null Move Heuristic.

### DIFF
--- a/include/board_state.h
+++ b/include/board_state.h
@@ -75,6 +75,16 @@ public:
   void undo_move();
 
   /**
+   * @brief Will apply a null move unto board_state;
+   */
+  void apply_null_move();
+
+  /**
+   * @brief Will undo a null move unto board_state;
+   */
+  void undo_null_move();
+
+  /**
    * @brief Checks if the given square is attacked.
    *
    * @param x_coordinate, y_coordinate The coordinate of the square.

--- a/include/search_engine.h
+++ b/include/search_engine.h
@@ -65,6 +65,9 @@ private:
   // Transposition Table object.
   TranspositionTable transposition_table;
 
+  // The max depth the current iterative search will reach.
+  int max_iterative_search_depth;
+
   /**
    * @brief Recursive function to find the best move using minimax algorithm
    * with alpha beta pruning.
@@ -79,7 +82,8 @@ private:
    * @return Evaluation score from search branch.
    */
   auto minimax_alpha_beta_search(BoardState &board_state, int alpha, int beta,
-                                 int depth, bool maximise) -> int;
+                                 int depth, bool maximise,
+                                 bool previous_move_is_null = false) -> int;
 
   /**
    * @brief Sorts the moves based on their scores.

--- a/src/board_state.cpp
+++ b/src/board_state.cpp
@@ -229,6 +229,18 @@ void BoardState::undo_move() {
   previous_move_stack.pop();
 }
 
+void BoardState::apply_null_move() {
+  // Update move color, it is now the other player's turn.
+  color_to_move = (color_to_move == PieceColor::WHITE) ? PieceColor::BLACK
+                                                       : PieceColor::WHITE;
+}
+
+void BoardState::undo_null_move() {
+  // Update move color, it is now the other player's turn.
+  color_to_move = (color_to_move == PieceColor::WHITE) ? PieceColor::BLACK
+                                                       : PieceColor::WHITE;
+}
+
 auto BoardState::square_is_attacked(int x, int y,
                                     PieceColor color_being_attacked) -> bool {
   // Check for pawn attacks


### PR DESCRIPTION
Player would make a null move (worst move in most cases), and search (at a shallower depth) and if it still causes an alpha beta cutoff, then return.
Current conditions to make a null move prevents null moves from being done back-to-back. This will prevent searches from being too shallow.