### PR TITLE
Simplify Evaluation

### DIFF
--- a/include/chess_engine.h
+++ b/include/chess_engine.h
@@ -2,10 +2,10 @@
 #define CHESS_ENGINE
 
 #include "board_state.h"
+#include "cross_plat_functions.h"
 #include "move_interface.h"
 #include "search_engine.h"
 
-#include <conio.h>
 #include <functional>
 #include <sstream>
 

--- a/include/cross_plat_functions.h
+++ b/include/cross_plat_functions.h
@@ -1,0 +1,18 @@
+#include <string>
+
+#ifdef _WIN32
+#include <conio.h>
+#include <windows.h>
+#else
+#include <sys/select.h>
+#include <unistd.h>
+#endif
+
+/**
+ * @brief Checks if input is available.
+ *
+ * @details This function is platform dependent.
+ *
+ * @return True if input is available, false otherwise.
+ */
+auto inputAvailable() -> bool;

--- a/include/position_evaluator.h
+++ b/include/position_evaluator.h
@@ -12,6 +12,8 @@ namespace engine::parts::position_evaluator
 /**
  * @brief Evaluates current position using chess heuristics.
  *
+ * @note Positive score is good for white, negative score is good for black.
+ *
  * @param board_state BoardState object to evaluate.
  *
  * @return Score of the given position.

--- a/include/search_engine.h
+++ b/include/search_engine.h
@@ -216,7 +216,7 @@ private:
    * @param alpha Highest score to be picked by maximizing node.
    * @param beta Lowest score to be picked by minimizing node.
    * @param depth Current depth of search.
-   * @param null_move_line Flag to indicate if the search line is from a null
+   * @param is_null_move_line Flag to indicate if the search line is from a null
    * move.
    *
    * @return Evaluation score from search branch.
@@ -225,7 +225,7 @@ private:
                                  int alpha,
                                  int beta,
                                  int depth,
-                                 bool null_move_line) -> int;
+                                 bool is_null_move_line) -> int;
 
   /**
    * @brief Sorts the moves based on their scores.
@@ -245,7 +245,7 @@ private:
    * @param depth Current depth of search.
    * @param best_move_index Index of best move.
    * @param possible_moves Vector of possible moves.
-   * @param null_move_line Flag to indicate if the search line is from a null
+   * @param is_null_move_line Flag to indicate if the search line is from a null
    * move.
    */
   void run_negamax_procedure(BoardState &board_state,
@@ -256,7 +256,7 @@ private:
                              int &depth,
                              int &best_move_index,
                              std::vector<Move> &possible_moves,
-                             bool &null_move_line);
+                             bool &is_null_move_line);
 
   /**
    * @brief Min search procedure for each possible move.

--- a/src/chess_engine.cpp
+++ b/src/chess_engine.cpp
@@ -296,7 +296,7 @@ void ChessEngine::handle_player_during_engine_turn()
     while (search_engine.engine_is_searching())
     {
       // Check if input is available
-      if (_kbhit() != 0)
+      if (inputAvailable())
       {
         // Read input
         std::getline(std::cin, userInput);

--- a/src/cross_plat_functions.cpp
+++ b/src/cross_plat_functions.cpp
@@ -1,0 +1,22 @@
+#include "cross_plat_functions.h"
+
+auto inputAvailable() -> bool
+{
+#ifdef _WIN32
+  if (_kbhit())
+  {
+    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD events;
+    GetNumberOfConsoleInputEvents(hStdin, &events);
+    return events > 0;
+  }
+  return false;
+#else
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(STDIN_FILENO, &fds);
+
+  struct timeval timeout = {0, 0}; // No blocking, just check
+  return select(STDIN_FILENO + 1, &fds, nullptr, nullptr, &timeout) > 0;
+#endif
+}

--- a/src/cross_plat_functions.cpp
+++ b/src/cross_plat_functions.cpp
@@ -3,7 +3,7 @@
 auto inputAvailable() -> bool
 {
 #ifdef _WIN32
-  if (_kbhit())
+  if (_kbhit() != 0)
   {
     HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
     DWORD events;

--- a/src/position_evaluator.cpp
+++ b/src/position_evaluator.cpp
@@ -7,6 +7,10 @@ namespace engine::parts::position_evaluator
 auto evaluate_position(BoardState &board_state) -> int
 {
   int eval = 0;
+  // We pass eval_temp to evaluators now instead of eval directly. This way, the
+  // functions can evaluate white and black pieces the same way (positively). We
+  // can then check the piece color and add or subtract accordingly to the
+  // actual eval.
   int eval_temp = 0;
 
   for (int y_position = Y_MIN; y_position <= Y_MAX; ++y_position)
@@ -42,6 +46,7 @@ auto evaluate_position(BoardState &board_state) -> int
         break;
       }
 
+      // If piece is black, subtract the evaluation.
       if (piece_type != PieceType::EMPTY)
       {
         if (piece.piece_color == PieceColor::WHITE)
@@ -132,6 +137,27 @@ void evaluate_bishop(int x_position,
   if (!bishop_piece.piece_has_moved)
   {
     eval -= LARGE_EVAL_VALUE;
+  }
+
+  // If bishop is blocking a pawn, decrease evaluation.
+  // When I play, I don't like it when my bishops block my pawns.
+  // This is a personal preference and is experimental.
+  int direction;
+  if (bishop_piece.piece_color == PieceColor::WHITE)
+  {
+    direction = POSITIVE_DIRECTION;
+  }
+  else
+  {
+    direction = NEGATIVE_DIRECTION;
+  }
+  if (y_position + direction >= Y_MIN && y_position + direction <= Y_MAX)
+  {
+    if (board_state.chess_board[x_position][y_position + direction]
+            ->piece_type == PieceType::PAWN)
+    {
+      eval -= LARGE_EVAL_VALUE;
+    }
   }
 
   // The more moves a bishop has, the better.

--- a/src/position_evaluator.cpp
+++ b/src/position_evaluator.cpp
@@ -7,37 +7,51 @@ namespace engine::parts::position_evaluator
 auto evaluate_position(BoardState &board_state) -> int
 {
   int eval = 0;
+  int eval_temp = 0;
 
   for (int y_position = Y_MIN; y_position <= Y_MAX; ++y_position)
   {
     for (int x_position = X_MIN; x_position <= X_MAX; ++x_position)
     {
+      eval_temp = 0;
       Piece &piece = *board_state.chess_board[x_position][y_position];
       PieceType &piece_type = piece.piece_type;
 
       switch (piece_type)
       {
       case PieceType::PAWN:
-        evaluate_pawn(x_position, y_position, piece, eval, board_state);
+        evaluate_pawn(x_position, y_position, piece, eval_temp, board_state);
         break;
       case PieceType::ROOK:
-        evaluate_rook(x_position, y_position, piece, eval, board_state);
+        evaluate_rook(x_position, y_position, piece, eval_temp, board_state);
         break;
       case PieceType::KNIGHT:
-        evaluate_knight(x_position, y_position, piece, eval, board_state);
+        evaluate_knight(x_position, y_position, piece, eval_temp, board_state);
         break;
       case PieceType::BISHOP:
-        evaluate_bishop(x_position, y_position, piece, eval, board_state);
+        evaluate_bishop(x_position, y_position, piece, eval_temp, board_state);
         break;
       case PieceType::QUEEN:
-        evaluate_queen(x_position, y_position, piece, eval, board_state);
+        evaluate_queen(x_position, y_position, piece, eval_temp, board_state);
         break;
       case PieceType::KING:
-        evaluate_king(x_position, y_position, piece, eval, board_state);
+        evaluate_king(x_position, y_position, piece, eval_temp, board_state);
         break;
       default:
         // Empty square.
         break;
+      }
+
+      if (piece_type != PieceType::EMPTY)
+      {
+        if (piece.piece_color == PieceColor::WHITE)
+        {
+          eval += eval_temp;
+        }
+        else
+        {
+          eval -= eval_temp;
+        }
       }
     }
   }
@@ -191,14 +205,7 @@ void evaluate_queen(int x_position,
                     BoardState &board_state)
 {
   // Piece value.
-  if (queen_piece.piece_color == PieceColor::WHITE)
-  {
-    eval += QUEEN_VALUE;
-  }
-  else
-  {
-    eval -= QUEEN_VALUE;
-  }
+  eval += QUEEN_VALUE;
 
   // The more moves a queen has, the better.
   int new_x;
@@ -233,6 +240,7 @@ void evaluate_king(int x_position,
 {
   // Piece value.
   eval += KING_VALUE;
+
   if (!board_state.is_end_game)
   {
     // Give eval points if the king has castled, but not in the end game where

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -374,6 +374,10 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
     leaf_nodes_visited.fetch_add(1, std::memory_order_relaxed);
 
     eval = engine::parts::position_evaluator::evaluate_position(board_state);
+
+    // The evaluator returns evaluations where positive eval is good for white
+    // and negative eval is good for black. Since negamax nodes are always
+    // maximizing nodes, we need to negate the eval for black.
     if (board_state.color_to_move == PieceColor::BLACK)
     {
       return -eval;

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -299,13 +299,15 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
                                              int depth,
                                              bool is_null_move_line) -> int
 {
-  // Increment nodes visited.
-  nodes_visited.fetch_add(1, std::memory_order_relaxed);
-
+  // Check if the engine wants to stop searching.
   if (!running_search_flag)
   {
     return 0;
   }
+
+  // Increment nodes visited.
+  nodes_visited.fetch_add(1, std::memory_order_relaxed);
+
   // If the king is no longer in the board, checkmate has occurred.
   // Return -INF evaluation for the side that has lost its king.
   // NOTE: We minus the depth in which the checkmate was found from INF. This

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -360,6 +360,10 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
   {
     eval = engine::parts::position_evaluator::evaluate_position(board_state);
     leaf_nodes_visited.fetch_add(1, std::memory_order_relaxed);
+    if (board_state.color_to_move == PieceColor::BLACK)
+    {
+      return -eval;
+    }
     return eval;
   }
 

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -311,13 +311,10 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
   // NOTE: We minus the depth in which the checkmate was found from INF. This
   // means checkmates found at shallower depths will have a higher eval.
   // We want to choose the shortest checkmate line.
-  if (board_state.color_to_move == PieceColor::WHITE &&
-      !board_state.white_king_on_board)
-  {
-    return -INF + max_iterative_search_depth - depth;
-  }
-  if (board_state.color_to_move == PieceColor::BLACK &&
-      !board_state.black_king_on_board)
+  if ((board_state.color_to_move == PieceColor::WHITE &&
+       !board_state.white_king_on_board) ||
+      (board_state.color_to_move == PieceColor::BLACK &&
+       !board_state.black_king_on_board))
   {
     return -INF + max_iterative_search_depth - depth;
   }

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -273,13 +273,19 @@ auto SearchEngine::run_search_with_aspiration_window(BoardState &board_state,
     eval = -negamax_alpha_beta_search(board_state, -beta, -alpha, depth - 1,
                                       false);
 
-    if (!running_search_flag)
-    {
-      break;
-    }
+    // An eval of abs(INF) means a checkmate position has been found. At the
+    // leaf node, we minus the depth the checkmate was found from INF before
+    // returning it. So the eval of a chekmate line will be less than
+    // INF. Hence why we check using INF_MINUS_1000. Any eval greater than
+    // INF_MINUS_1000 is a checkmate line.
+    const int INF_MINUS_1000 = -1000;
 
-    // Return eval if it is within the window.
-    if (eval < beta && eval > alpha)
+    // - Return eval if it is within the window.
+    // - Return eval if search has stopped.
+    // - Return eval if eval if a checkmate line has been found, no need to
+    // widen the window and re-search.
+    if ((eval < beta && eval > alpha) || !running_search_flag ||
+        std::abs(eval) > INF_MINUS_1000)
     {
       break;
     }
@@ -291,7 +297,7 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
                                              int alpha,
                                              int beta,
                                              int depth,
-                                             bool null_move_line) -> int
+                                             bool is_null_move_line) -> int
 {
   if (!running_search_flag)
   {
@@ -368,7 +374,9 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
   }
 
   // Try a null move.
-  if (!null_move_line &&
+  // We curently only allow one null move per search line, and only when
+  // MIN_NULL_MOVE_DEPTH depth has been reached.
+  if (!is_null_move_line &&
       (max_iterative_search_depth - depth) >= MIN_NULL_MOVE_DEPTH &&
       !board_state.is_end_game)
   {
@@ -395,7 +403,7 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
 
   // Search and evaluate each move.
   run_negamax_procedure(board_state, alpha, beta, max_eval, eval, depth,
-                        best_move_index, possible_moves, null_move_line);
+                        best_move_index, possible_moves, is_null_move_line);
 
   // If search has stopped, don't save the states in the transposition
   // table. This will cause invalid states to be stored with eval scores of 0.
@@ -426,7 +434,7 @@ void SearchEngine::run_negamax_procedure(BoardState &board_state,
                                          int &depth,
                                          int &best_move_index,
                                          std::vector<Move> &possible_moves,
-                                         bool &null_move_line)
+                                         bool &is_null_move_line)
 {
   for (int move_index = 0; move_index < possible_moves.size(); ++move_index)
   {
@@ -434,7 +442,7 @@ void SearchEngine::run_negamax_procedure(BoardState &board_state,
     // We only want to know if there is an eval greater than beta, hence make
     // the search window tight.
     eval = -negamax_alpha_beta_search(board_state, -beta, -alpha, depth - 1,
-                                      null_move_line);
+                                      is_null_move_line);
     if (eval > max_eval)
     {
       max_eval = eval;

--- a/src/search_engine.cpp
+++ b/src/search_engine.cpp
@@ -360,10 +360,6 @@ auto SearchEngine::negamax_alpha_beta_search(BoardState &board_state,
   {
     eval = engine::parts::position_evaluator::evaluate_position(board_state);
     leaf_nodes_visited.fetch_add(1, std::memory_order_relaxed);
-    if (board_state.color_to_move == PieceColor::BLACK)
-    {
-      return -eval;
-    }
     return eval;
   }
 


### PR DESCRIPTION
Eval functions for a piece evaluate positively now, it used to be negative for black. This will make the functions more readable with less conditions to determine if a piece is white or black. Black still has to be negative eval, but we do it externally, and only once.