### PR TITLE
Implement Three-Fold Repetition Rule

### DIFF
--- a/include/board_state.h
+++ b/include/board_state.h
@@ -172,7 +172,7 @@ public:
    *
    * @return The Zobrist hash value.
    */
-  [[nodiscard]] auto compute_zobrist_hash() const -> size_t;
+  [[nodiscard]] auto compute_zobrist_hash() const -> uint64_t;
 
   /**
    * @brief Makes all squares empty.
@@ -183,12 +183,13 @@ private:
   // PROPERTIES
 
   /// @brief Zobrist keys.
-  std::array<std::array<std::array<size_t, NUM_OF_COLORS>, NUM_OF_PIECE_TYPES>,
-             NUM_OF_SQUARES>
+  std::array<
+      std::array<std::array<uint64_t, NUM_OF_COLORS>, NUM_OF_PIECE_TYPES>,
+      NUM_OF_SQUARES>
       zobrist_keys;
 
   /// @brief Zobrist key for the side to move.
-  size_t zobrist_side_to_move;
+  uint64_t zobrist_side_to_move;
 
   /// @brief All empty squares point to the same Piece instance.
   Piece empty_piece;

--- a/src/board_state.cpp
+++ b/src/board_state.cpp
@@ -394,9 +394,9 @@ auto BoardState::move_leaves_king_in_check(Move &move) -> bool
   return king_is_checked_after_move;
 }
 
-auto BoardState::compute_zobrist_hash() const -> size_t
+auto BoardState::compute_zobrist_hash() const -> uint64_t
 {
-  size_t hash = 0;
+  uint64_t hash = 0;
 
   for (int y_position = Y_MIN; y_position <= Y_MAX; ++y_position)
   {
@@ -459,7 +459,7 @@ void BoardState::clear_pointers()
 void BoardState::initialize_zobrist_keys()
 {
   std::mt19937_64 rng(0); // Use a fixed seed for reproducibility
-  std::uniform_int_distribution<size_t> dist;
+  std::uniform_int_distribution<uint64_t> dist;
 
   for (int square = 0; square < NUM_OF_SQUARES; ++square)
   {

--- a/src/chess_engine.cpp
+++ b/src/chess_engine.cpp
@@ -118,6 +118,11 @@ void ChessEngine::engine_vs_player_state()
 
 void ChessEngine::check_and_handle_if_game_over()
 {
+  if (game_board_state.current_state_has_been_repeated_three_times())
+  {
+    printf("\nThreefold Repetition, It's a draw!\n");
+    game_over = true;
+  }
   if (!game_over && engine::parts::SearchEngine::is_stalemate(game_board_state))
   {
     printf("\nStalemate, It's a draw!\n");


### PR DESCRIPTION
If a position is visited 3 times, the game will be drawn.

The engine now decrements the score of a move by 1 if the resulting position of the move has been visited before.
This should make the engine less likely to loop between states with the same eval score.