### PR TITLE
Patch Queen Side Castle

### DIFF
--- a/src/move_generator.cpp
+++ b/src/move_generator.cpp
@@ -349,7 +349,7 @@ void generate_castle_king_moves(BoardState &board_state,
     // Castle queen side.
     potential_rook_piece = chess_board[X_MIN][y_rank];
     if (can_castle(board_state, king_piece, y_rank, potential_rook_piece,
-                   {XB_FILE, XC_FILE, XD_FILE}))
+                   {XC_FILE, XD_FILE}))
     {
       possible_normal_moves.emplace_back(x_file, y_rank, x_file - 2, y_rank,
                                          king_piece, first_move, false);

--- a/testing/chess_board_fen_configs/castle_queen_side_test.txt
+++ b/testing/chess_board_fen_configs/castle_queen_side_test.txt
@@ -1,0 +1,1 @@
+r2k3r/1pp2p1p/5p2/p1b1nb2/2P5/2N2N2/PP4PP/R3KB1R w KQ - 0 1


### PR DESCRIPTION
Move generator was checking the B File when checking if the King can castle queen side. This was not a chess rule and the king can castle even if the B File is attacked.